### PR TITLE
More tests, and new 'setup' phase for testing

### DIFF
--- a/lib/js/js-test
+++ b/lib/js/js-test
@@ -58,6 +58,7 @@ sub generate_qunit_code {
         my $test_cases = $test_src->{$function_name};
         foreach my $test ( @$test_cases ) {
             $js .= generate_qunit_test(
+                        $test->{setup},
                         $function_name,
                         $test->{description},
                         $test->{text},
@@ -96,19 +97,25 @@ sub run_test_file {
 sub generate_qunit_module {
     my ($function_name) = @_;
 
-    return qq(
-            QUnit.module("$function_name");
-    );
+    return qq(\n        QUnit.module("$function_name");\n);
 }
 
 sub generate_qunit_test {
+    my $setup = shift;
     my ($function_name, $description, $text, $expected) = escape( @_ );
 
-    return qq(
-            QUnit.test( "$description", function( assert ) {
+    my $str = qq|\n            QUnit.test( "$description", function( assert ) {|;
+    if ($setup) {
+        foreach my $item (@$setup) {
+            my ($function, $value) = each (%$item);
+            $str .= qq|\n                emojione.$function = $value|;
+        }
+    }
+    $str .= qq|
                 assert.equal( emojione.$function_name("$text"), "$expected" );
-            });
-    );
+            });\n|;
+
+    return $str;
 }
 
 sub escape {

--- a/lib/validate.yml
+++ b/lib/validate.yml
@@ -27,6 +27,14 @@ tests:
     - description: "mixed ascii, regular unicode and duplicate emoji"
       text: "👽 is not :alien: and 저 is not 👽 or 👽"
       expected: ":alien: is not :alien: and 저 is not :alien: or :alien:"
+    - description: "ascii art parsing doesn't work in toShort"
+      setup:
+        - ascii: true
+      text: ":)"
+      expected: ":)"
+    - description: "ascii art not parsed by default"
+      text: ":)"
+      expected: ":)"
     - description: "multiline emoji string"
       text: "💃\n💃"
       expected: ":dancer:\n:dancer:"
@@ -36,10 +44,37 @@ tests:
   toImage:
     - description: "single character shortname conversion"
       text: ":snail:"
-      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png\"/>"
+      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png?v=1.2.3\"/>"
     - description: "shortname shares a colon"
       text: ":invalid:snail:"
       expected: ":invalid:snail:"
     - description: "single unicode character conversion"
       text: "🐌"
-      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png\"/>"
+      expected: "<img class=\"emojione\" alt=\"🐌\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F40C.png?v=1.2.3\"/>"
+    - description: "ascii art disabled by default in toImage"
+      text: ":)"
+      expected: ":)"
+    - description: "ascii art parsing works in toImage"
+      setup:
+        - ascii: true
+      text: ":)"
+      expected: "<img class=\"emojione\" alt=\"😄\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F604.png?v=1.2.3\"/>"
+    - description: "setting images to svg"
+      setup:
+        - imageType: "'svg'"
+        - ascii: true
+      text: ":)"
+      expected: "<object class=\"emojione\" data=\"//cdn.jsdelivr.net/emojione/assets/svg/1F604.svg?v=1.2.3\" type=\"image/svg+xml\" standby=\"😄\">😄</object>"
+  shortnameToImage:
+    - description: "basic conversion"
+      setup:
+        - imageType: "'png'"
+        - ascii: false
+      text: "Hello, :snowman:"
+      expected: "Hello, <img class=\"emojione\" alt=\"⛄\" src=\"//cdn.jsdelivr.net/emojione/assets/png/26C4.png?v=1.2.3\"/>"
+  unicodeToImage:
+    - description: "basic conversion from unicode to image"
+      setup:
+        - imageType: "'png'"
+      text: "Hello, 😄!"
+      expected: "Hello, <img class=\"emojione\" alt=\"😄\" src=\"//cdn.jsdelivr.net/emojione/assets/png/1F604.png?v=1.2.3\"/>!"


### PR DESCRIPTION
As @kevinranks asked in #12, this PR adds an optional "setup" phase for each test. The "js-test" qUnit test generator already supports it, and to demonstrate I have added a few new tests to ```validate.yml```, increasing overall coverage.

Hope this helps! Again, as usual, please let me know if you have any questions or bump into any issue! :)