### PR TITLE
asciiToUnicodeCallback removed the character preceding the ascii emoji.

### DIFF
--- a/lib/php/src/Emojione.php
+++ b/lib/php/src/Emojione.php
@@ -2503,7 +2503,7 @@ class Emojione {
         else {
             $shortname = $m[3];
             $unicode = self::$ascii_replace[$shortname];
-            return self::convert($unicode);
+            return $m[2].self::convert($unicode);
         }
     }
     static function asciiToImageCallback($m) {


### PR DESCRIPTION
This was fixed in the JS, but not the PHP in a previous commit, so this fixes it here.
