### PR TITLE
Fix SVG support under Chrome

### DIFF
--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -328,7 +328,7 @@
                         replaceWith = '<svg class="emojione"><description>'+alt+'</description><use xlink:href="'+ns.imagePathSVGSprites+'#emoji-'+unicode.toUpperCase()+'"></use></svg>';
                     }
                     else {
-                        replaceWith = '<object class="emojione" data="'+ns.imagePathSVG+unicode+'.svg'+ns.cacheBustParam+'" type="image/svg+xml" standby="'+alt+'">'+alt+'</object>';
+                        replaceWith = '<img class="emojione" alt="'+alt+'" src="'+ns.imagePathSVG+unicode+'.svg'+ns.cacheBustParam+'"/>';
                     }
                 }
 


### PR DESCRIPTION
Currently Emojione load SVG images through an <object> tag this has two disadvantage compared to standard img :
- Copy/Paste does not copy the utf8 character and thus does not work properly
- There is a MAJOR issue with recent version of Chrome and object SVG, this is slow as hell, freeze the page rendering and create a mini DOS if the same emoji is used several time.

Img svg has a decent support similar to object (see http://caniuse.com/#feat=svg-img), object for svg is mostly used for old school html only automated fallback (which is not used in emojione).

This pull request replaces object svg loading by standard img loading.

Here is the effect on the network panel on chrome for this page
![screenshot 2015-01-23 17 20 39](https://cloud.githubusercontent.com/assets/7854/5878272/f2d64a4c-a325-11e4-908e-d9da0c136811.png)

Object SVG (crazy network nightmare, svg loaded several time for the same emoji):
![screenshot 2015-01-23 17 19 26](https://cloud.githubusercontent.com/assets/7854/5878275/fcbe83e4-a325-11e4-94ec-d43bd71c19e7.png)

Img SVG (completly normal, only a loading when the same emoji is used several time):
![screenshot 2015-01-23 17 29 45](https://cloud.githubusercontent.com/assets/7854/5878280/ffc088d0-a325-11e4-87b9-c61c71344d08.png)