### PR TITLE
Fix RegExp to match non-breaking space (U+C2A0)

### DIFF
--- a/lib/php/src/Client.php
+++ b/lib/php/src/Client.php
@@ -81,7 +81,7 @@ class Client implements ClientInterface
             $ruleset = $this->getRuleset();
             $asciiRegexp = $ruleset->getAsciiRegexp();
 
-            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|'.hex2bin('c2a0').'|^)'.$asciiRegexp.'(?=\\s|'.hex2bin('c2a0').'|$|[!,\.]))/S', array($this, 'asciiToUnicodeCallback'), $string);
+            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|'.\hex2bin('c2a0').'|^)'.$asciiRegexp.'(?=\\s|'.\hex2bin('c2a0').'|$|[!,\.]))/S', array($this, 'asciiToUnicodeCallback'), $string);
         }
 
         return $string;
@@ -117,7 +117,7 @@ class Client implements ClientInterface
             $ruleset = $this->getRuleset();
             $asciiRegexp = $ruleset->getAsciiRegexp();
 
-            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|'.hex2bin('c2a0').'|^)'.$asciiRegexp.'(?=\\s|'.hex2bin('c2a0').'|$|[!,\.]))/S', array($this, 'asciiToImageCallback'), $string);
+            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|'.\hex2bin('c2a0').'|^)'.$asciiRegexp.'(?=\\s|'.\hex2bin('c2a0').'|$|[!,\.]))/S', array($this, 'asciiToImageCallback'), $string);
         }
 
         return $string;

--- a/lib/php/src/Client.php
+++ b/lib/php/src/Client.php
@@ -81,7 +81,7 @@ class Client implements ClientInterface
             $ruleset = $this->getRuleset();
             $asciiRegexp = $ruleset->getAsciiRegexp();
 
-            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|\x{C2A0}|^)'.$asciiRegexp.'(?=\\s|\x{C2A0}|$|[!,\.]))/Su', array($this, 'asciiToUnicodeCallback'), $string);
+            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|'.hex2bin('c2a0').'|^)'.$asciiRegexp.'(?=\\s|'.hex2bin('c2a0').'|$|[!,\.]))/S', array($this, 'asciiToUnicodeCallback'), $string);
         }
 
         return $string;
@@ -117,7 +117,7 @@ class Client implements ClientInterface
             $ruleset = $this->getRuleset();
             $asciiRegexp = $ruleset->getAsciiRegexp();
 
-            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|\x{C2A0}|^)'.$asciiRegexp.'(?=\\s|\x{C2A0}|$|[!,\.]))/Su', array($this, 'asciiToImageCallback'), $string);
+            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|'.hex2bin('c2a0').'|^)'.$asciiRegexp.'(?=\\s|'.hex2bin('c2a0').'|$|[!,\.]))/S', array($this, 'asciiToImageCallback'), $string);
         }
 
         return $string;

--- a/lib/php/src/Client.php
+++ b/lib/php/src/Client.php
@@ -81,7 +81,7 @@ class Client implements ClientInterface
             $ruleset = $this->getRuleset();
             $asciiRegexp = $ruleset->getAsciiRegexp();
 
-            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|^)'.$asciiRegexp.'(?=\\s|$|[!,\.]))/S', array($this, 'asciiToUnicodeCallback'), $string);
+            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|\x{C2A0}|^)'.$asciiRegexp.'(?=\\s|\x{C2A0}|$|[!,\.]))/Su', array($this, 'asciiToUnicodeCallback'), $string);
         }
 
         return $string;
@@ -117,7 +117,7 @@ class Client implements ClientInterface
             $ruleset = $this->getRuleset();
             $asciiRegexp = $ruleset->getAsciiRegexp();
 
-            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|^)'.$asciiRegexp.'(?=\\s|$|[!,\.]))/S', array($this, 'asciiToImageCallback'), $string);
+            $string = preg_replace_callback('/'.$this->ignoredRegexp.'|((\\s|\x{C2A0}|^)'.$asciiRegexp.'(?=\\s|\x{C2A0}|$|[!,\.]))/Su', array($this, 'asciiToImageCallback'), $string);
         }
 
         return $string;


### PR DESCRIPTION
When using Emoji in a `contenteditable="true"` editor (like TinyMCE or other WYSIWYG-Editors) some browsers (current Chrome version) may sometimes insert non-breaking spaces (U+C2A0) instead of normal spaces. This will lead to a misbehavior of EmojiOne since ASCII emoji are only replaced with a leading and trailing space.

Imagine the user inputs the text

```
i like emoji :-) very much
```

results in

```
i like emoji :-)\uC2A0very much
```

The `:-)` emoji won't be replaced when typed in Chrome / TinyMCE.