### PR TITLE
Issue #199

### DIFF
--- a/lib/php/src/Client.php
+++ b/lib/php/src/Client.php
@@ -355,11 +355,16 @@ class Client implements ClientInterface
 
             if (!in_array($unicode, $unicode_replace))
             {
-                $unicode = substr($m[1], 0, 4);
+                $unicode .= "\xEF\xB8\x8F";
 
                 if (!in_array($unicode, $unicode_replace))
                 {
-                    return $m[0];
+                    $unicode = substr($m[1], 0, 4);
+
+                    if (!in_array($unicode, $unicode_replace))
+                    {
+                        return $m[0];
+                    }
                 }
             }
 


### PR DESCRIPTION
If character doesn't match, append Variation Selector U+FE0F, and try again.
This seems to be a way better solution than stripping off the Variation Selectors.