### PR TITLE
Add sprites by default on Meteor package

### DIFF
--- a/package.js
+++ b/package.js
@@ -25,21 +25,9 @@ Package.onUse(function(api) {
     'assets/css/emojione.css',
   ], 'client');
 
-  if ((process.env.EMOJIONE_ADD_SVG_SPRITES !== undefined && process.env.EMOJIONE_ADD_SVG_SPRITES.toLowerCase() === 'true') || (process.env.EMOJIONE_ADD_PNG_SPRITES !== undefined && process.env.EMOJIONE_ADD_PNG_SPRITES.toLowerCase() === 'true')) {
-    api.addFiles([
-      'assets/sprites/emojione.sprites.css',
-    ], 'client');
-    if (process.env.EMOJIONE_ADD_SVG_SPRITES) {
-        api.addAssets([
-          'assets/sprites/emojione.sprites.svg'
-        ], 'client');
-    }
-    if (process.env.EMOJIONE_ADD_PNG_SPRITES) {
-        api.addAssets([
-          'assets/sprites/emojione.sprites.png'
-        ], 'client');
-    }
-  }
+  api.addAssets('assets/sprites/emojione.sprites.css', 'client');
+  api.addAssets('assets/sprites/emojione.sprites.svg', 'client');
+  api.addAssets('assets/sprites/emojione.sprites.png', 'client');
 
   api.export('emojione');
 });

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'emojione:emojione',
   summary: 'Meteor Package of http://www.emojione.com/ set',
-  version: '2.1.2',
+  version: '2.1.2_1',
   git: 'https://github.com/Ranks/emojione.git'
 });
 


### PR DESCRIPTION
We (at Rocket.Chat) realized that is not possible to use environmente variable on the `package.js` file, since it is read at build time and not at run time.

So, I'm adding the sprite assets by default. The way it is now, it is not possible to use the package with sprites.