### PR TITLE
Use HTTPS for jsdelivr links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ When storing user inputted text in your database, say from a guestbook or throug
 We've teamed up with [JSDelivr](http://www.jsdelivr.com/#!emojione) to provide a simple way to install these emoji on any javascript-enabled website. Add the following script and stylesheet links to the head of your webpage:
 
 ```
-<script src="//cdn.jsdelivr.net/emojione/2.2.6/lib/js/emojione.min.js"></script>
-<link rel="stylesheet" href="//cdn.jsdelivr.net/emojione/2.2.6/assets/css/emojione.min.css"/>
+<script src="https://cdn.jsdelivr.net/emojione/2.2.6/lib/js/emojione.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/emojione/2.2.6/assets/css/emojione.min.css"/>
 ```
 
 Alternatively, CDNjs is also available as a [CDN Host for Emoji One](https://cdnjs.com/libraries/emojione).


### PR DESCRIPTION
Protocol-relative URLs are now considered an anti-pattern, for several reasons:
 - They break when accessing local files (#347, #285)
 - TLS has barely any overhead on modern CPUs 
 - TLS is generally faster these days, due to SPDY and HTTP/2 **requiring** it. HTTP/2 uses a single connection with multiplexing so it's generally more efficient than HTTP/1.1
 -  It's always safe to request HTTPS assets even if your site is on HTTP, and can actually be beneficial in preventing man-in-the-middle attacks. This is especially important when loading scripts from a third-party domain

For these reasons, Emoji One should not suggest their usage, and instead always use HTTPS.

Closes #352, #347 