### PR TITLE
Fix JS tests broken by 64->32 change

### DIFF
--- a/lib/js/tests/tests.html
+++ b/lib/js/tests/tests.html
@@ -10,131 +10,131 @@
         <script src="http://cdn.jsdelivr.net/qunit/1.14.0/qunit.js"></script>
         <script src="../emojione.js"></script>
         <script>
-        
+
             QUnit.module("toImage");
-            
+
                 QUnit.test( "test toImage", function( assert ) {
-                    assert.equal(emojione.toImage("Hello world! 😄 :smile:"), "Hello world! <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f604.png\"/> <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f604.png\"/>");
+                    assert.equal(emojione.toImage("Hello world! 😄 :smile:"), "Hello world! <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f604.png\"/> <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f604.png\"/>");
                 });
-            
+
                 QUnit.test( "mixed ascii, regular unicode and duplicate emoji", function( assert ) {
-                    assert.equal(emojione.toImage(":alien: is 👽 and 저 is not :alien: or :alien: also :randomy: is not emoji"), "<img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/> is <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/> and 저 is not <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/> or <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/> also :randomy: is not emoji");
+                    assert.equal(emojione.toImage(":alien: is 👽 and 저 is not :alien: or :alien: also :randomy: is not emoji"), "<img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/> is <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/> and 저 is not <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/> or <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/> also :randomy: is not emoji");
                 });
-            
-        
+
+
             QUnit.module("unifyUnicode");
-            
+
                 QUnit.test( "test unifyUnicode", function( assert ) {
                     assert.equal(emojione.unifyUnicode("Hello world! 😄 :smile:"), "Hello world! 😄 😄");
                 });
-            
+
                 QUnit.test( "mixed ascii, regular unicode and duplicate emoji", function( assert ) {
                     assert.equal(emojione.unifyUnicode(":alien: is 👽 and 저 is not :alien: or :alien: also :randomy: is not emoji"), "👽 is 👽 and 저 is not 👽 or 👽 also :randomy: is not emoji");
                 });
-            
+
                 QUnit.test( "multiline emoji string", function( assert ) {
                     assert.equal(emojione.unifyUnicode(":dancer:\
 :dancer:"), "💃\
 💃");
                 });
-            
+
                 QUnit.test( "triple emoji string", function( assert ) {
                     assert.equal(emojione.unifyUnicode(":dancer::dancer::alien:"), "💃💃👽");
                 });
-            
-        
+
+
             QUnit.module("shortnameToUnicode");
-            
+
                 QUnit.test( "single unicode character conversion", function( assert ) {
                     assert.equal(emojione.shortnameToUnicode("Hello world! 😄 :smile:"), "Hello world! 😄 😄");
                 });
-            
+
                 QUnit.test( "shortname at start of sentence with apostrophe", function( assert ) {
                     assert.equal(emojione.shortnameToUnicode(":snail:'s are cool!"), "🐌's are cool!");
                 });
-            
+
                 QUnit.test( "shortname shares a colon", function( assert ) {
                     assert.equal(emojione.shortnameToUnicode(":invalid:snail:"), ":invalid🐌");
                 });
-            
+
                 QUnit.test( "mixed ascii, regular unicode and duplicate emoji", function( assert ) {
                     assert.equal(emojione.shortnameToUnicode(":alien: is 👽 and 저 is not :alien: or :alien: also :randomy: is not emoji"), "👽 is 👽 and 저 is not 👽 or 👽 also :randomy: is not emoji");
                 });
-            
+
                 QUnit.test( "multiline emoji string", function( assert ) {
                     assert.equal(emojione.shortnameToUnicode(":dancer:\n:dancer:"), "💃\n💃");
                 });
-            
+
                 QUnit.test( "triple emoji string", function( assert ) {
                     assert.equal(emojione.shortnameToUnicode(":dancer::dancer::alien:"), "💃💃👽");
                 });
-            
-        
+
+
             QUnit.module("shortnameToImage");
-            
+
                 QUnit.test( "single shortname character conversion", function( assert ) {
-                    assert.equal(emojione.shortnameToImage("Hello world! 😄 :smile:"), "Hello world! 😄 <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f604.png\"/>");
+                    assert.equal(emojione.shortnameToImage("Hello world! 😄 :smile:"), "Hello world! 😄 <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f604.png\"/>");
                 });
-            
+
                 QUnit.test( "shortname at start of sentence with apostrophe", function( assert ) {
-                    assert.equal(emojione.shortnameToImage(":snail:'s are cool!"), "<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f40c.png\"/>'s are cool!");
+                    assert.equal(emojione.shortnameToImage(":snail:'s are cool!"), "<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f40c.png\"/>'s are cool!");
                 });
-            
+
                 QUnit.test( "shortname shares a colon", function( assert ) {
-                    assert.equal(emojione.shortnameToImage(":invalid:snail:"), ":invalid<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f40c.png\"/>");
+                    assert.equal(emojione.shortnameToImage(":invalid:snail:"), ":invalid<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f40c.png\"/>");
                 });
-            
+
                 QUnit.test( "mixed ascii, regular unicode and duplicate emoji", function( assert ) {
-                    assert.equal(emojione.shortnameToImage(":alien: is 👽 and 저 is not :alien: or :alien: also :randomy: is not emoji"), "<img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/> is 👽 and 저 is not <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/> or <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/> also :randomy: is not emoji");
+                    assert.equal(emojione.shortnameToImage(":alien: is 👽 and 저 is not :alien: or :alien: also :randomy: is not emoji"), "<img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/> is 👽 and 저 is not <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/> or <img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/> also :randomy: is not emoji");
                 });
-            
+
                 QUnit.test( "multiline emoji string", function( assert ) {
-                    assert.equal(emojione.shortnameToImage(":dancer:\n:dancer:"), "<img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f483.png\"/>\n<img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f483.png\"/>");
+                    assert.equal(emojione.shortnameToImage(":dancer:\n:dancer:"), "<img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f483.png\"/>\n<img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f483.png\"/>");
                 });
-            
+
                 QUnit.test( "triple emoji string", function( assert ) {
-                    assert.equal(emojione.shortnameToImage(":dancer::dancer::alien:"), "<img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f483.png\"/><img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f483.png\"/><img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f47d.png\"/>");
+                    assert.equal(emojione.shortnameToImage(":dancer::dancer::alien:"), "<img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f483.png\"/><img class=\"emojione\" alt=\"💃\" title=\":dancer:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f483.png\"/><img class=\"emojione\" alt=\"👽\" title=\":alien:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f47d.png\"/>");
                 });
-            
-        
+
+
             QUnit.module("toShort");
-            
+
                 QUnit.test( "single unicode character conversion", function( assert ) {
                     assert.equal(emojione.toShort("Hello world! 😄 :smile:"), "Hello world! :smile: :smile:");
                 });
-            
+
                 QUnit.test( "mixed ascii, regular unicode and duplicate emoji", function( assert ) {
                     assert.equal(emojione.toShort("👽 is not :alien: and 저 is not 👽 or 👽"), ":alien: is not :alien: and 저 is not :alien: or :alien:");
                 });
-            
+
                 QUnit.test( "multiline emoji string", function( assert ) {
                     assert.equal(emojione.toShort("💃\n💃"), ":dancer:\n:dancer:");
                 });
-            
+
                 QUnit.test( "alias vs. canonical", function( assert ) {
                     assert.equal(emojione.toShort("🇯🇵 どうもありがとう"), ":flag_jp: どうもありがとう");
                 });
-            
+
                 QUnit.test( "unicode character conversion within excluded tag", function( assert ) {
                     assert.equal(emojione.toShort("<div>😄</div>"), "<div>:smile:</div>");
                 });
-            
-        
+
+
             QUnit.module("toImage");
-            
+
                 QUnit.test( "single character shortname conversion", function( assert ) {
-                    assert.equal(emojione.toImage("Hello world! 😄 :smile:"), "Hello world! <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f604.png\"/> <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f604.png\"/>");
+                    assert.equal(emojione.toImage("Hello world! 😄 :smile:"), "Hello world! <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f604.png\"/> <img class=\"emojione\" alt=\"😄\" title=\":smile:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f604.png\"/>");
                 });
-            
+
                 QUnit.test( "shortname shares a colon", function( assert ) {
-                    assert.equal(emojione.toImage(":invalid:snail:"), ":invalid<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f40c.png\"/>");
+                    assert.equal(emojione.toImage(":invalid:snail:"), ":invalid<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f40c.png\"/>");
                 });
-            
+
                 QUnit.test( "single unicode character conversion", function( assert ) {
-                    assert.equal(emojione.toImage("🐌"), "<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/64/1f40c.png\"/>");
+                    assert.equal(emojione.toImage("🐌"), "<img class=\"emojione\" alt=\"🐌\" title=\":snail:\" src=\"https://cdn.jsdelivr.net/emojione/assets/3.0/png/32/1f40c.png\"/>");
                 });
-            
-        
+
+
         </script>
     </body>
 </html>


### PR DESCRIPTION
It appears that the change to add 32/64 emoji size broke the JS tests. I replaced the "64" in all these URLs with "32" and the tests are passing now.