### PR TITLE
Fix Performance on multiple invocation of toImage

### DIFF
--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -394,22 +394,34 @@
     };
 
     ns.shortnameConversionMap = function() {
+    	if (ns.memShortnameConversionMap) {
+    		return ns.memShortnameConversionMap;
+    	}
         var map = [], emoji;
         for (emoji in ns.emojioneList) {
             if (!ns.emojioneList.hasOwnProperty(emoji) || (emoji === '')) continue;
             map[ns.convert(ns.emojioneList[emoji].uc_output)] = emoji;
         }
-        return map;
+        return ns.memShortnameConversionMap = map;
     };
 
     ns.unicodeCharRegex = function() {
+    	if (ns.memUnicodeCharRegex) {
+    		return ns.memUnicodeCharRegex;
+    	}
         var map = [];
         for (emoji in ns.emojioneList) {
             if (!ns.emojioneList.hasOwnProperty(emoji) || (emoji === '')) continue;
             map.push(ns.convert(ns.emojioneList[emoji].uc_output));
         }
-        return map.join('|');
+        return ns.memUnicodeCharRegex = map.join('|');
     };
+
+    ns.changeEmojiList = function(newEmojiList) {
+    	ns.emojioneList = newEmojiList;
+    	ns.memUnicodeCharRegex = null;
+    	ns.memShortnameConversionMap = null;
+    },
 
     ns.mapEmojioneList = function (addToMapStorage) {
         for (var shortname in ns.emojioneList) {


### PR DESCRIPTION
We currently VueJs and apply the toImage function on a lot of components independently.

The toImage function builds the regex for the emojis every single time. After doing a detailed performance analysis, the toImage function spend most of its time to build the regex. Caching the result of these two functions immediately improved performance.