### PR TITLE
Fix JS thumbsup emoji shortname `:+1:`

### DIFF
--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -251,7 +251,7 @@
         var replaceWith,shortname,unicode,fname,alt,category,title,size,ePath;
         var mappedUnicode = ns.mapUnicodeToShort();
         str = str.replace(ns.regShortNames, function(shortname) {
-            if( (typeof shortname === 'undefined') || (shortname === '') || (ns.shortnames.indexOf(shortname) === -1) ) {
+            if( (typeof shortname === 'undefined') || (shortname === '') || (ns.shortnames.indexOf(shortname.replace(/[+]/g, '\\$&')) === -1) ) {
                 // if the shortname doesnt exist just return the entire match
                 return shortname;
             }


### PR DESCRIPTION
Escape `shortname` before matching against `ns.shortnames`.

Closes https://github.com/joypixels/emojione/issues/551